### PR TITLE
add optional parameter to force reload of already loaded baselines (in memory) from file system in order to reflect updated baselines

### DIFF
--- a/baselines/M365.TENANT.1-1.1.yml
+++ b/baselines/M365.TENANT.1-1.1.yml
@@ -82,7 +82,7 @@ Configuration:
         dropdownTimeoutValue: 360
       PasswordExpirationPolicyNeverExpire: true # User Passwords never expire
       PrivacyProfile: # Specifies whether the organization's privacy profile is configured.
-        PrivacyContact: PrivacyContact@yourdomain.com
+        PrivacyContact: "PrivacyContact@yourdomain.com"
         PrivacyStatement: "https://www.yourorg.com/privacy"
       Pronouns: # Specifies the pronouns of the organization.
         isEnabledInOrganization: true

--- a/src/Private/Validation/Test-M365.1-1.1.ps1
+++ b/src/Private/Validation/Test-M365.1-1.1.ps1
@@ -72,7 +72,7 @@ Function Test-M365.1-1.1 {
         $settings.MSGraphDataConnect = $extractedSettings.Services.MSGraphDataConnect
         $settings.MSLoop = $extractedSettings.Services.MSLoop
         $settings.MSPlanner = $extractedSettings.Services.MSPlanner
-        $settings.MSSearchBing = "n/a"
+        $settings.MSSearchBing = $null -eq $extractedSettings.Services.MSSearchBing ? $false : $true
         $settings.MSTeams = $extractedSettings.Services.MSTeams
         $settings.MSTeamsAllowGuestAccess = $extractedSettings.Services.MSTeamsAllowGuestAccess
         $settings.MSToDo = $extractedSettings.Services.MSToDo

--- a/src/Public/Validation/Start-Validation.ps1
+++ b/src/Public/Validation/Start-Validation.ps1
@@ -5,6 +5,10 @@ Function Start-Validation {
       HelpMessage = "Full name of the template, including .yml (aka <name>.yml)"
     )][string]$TemplateName,
     [Parameter(
+      Mandatory = $false,
+      HelpMessage = "Force reload of baselines (overwrites already loaded baselines in memory by reading from file system)"
+    )][Switch]$ReloadBaselines,
+    [Parameter(
       Mandatory = $false
     )][switch]$KeepConnectionsAlive,
     [Parameter(
@@ -33,10 +37,10 @@ Function Start-Validation {
       try {
         if ($tenantConfig.BaselinesPath) { 
           Write-Log "Trying to load baselines from path: '$($tenantConfig.BaselinesPath)'"
-          $baseline = Get-BaselineTemplate -BaselineId $selectedBaseline -BaselinesPath $tenantConfig.BaselinesPath 
+          $baseline = Get-BaselineTemplate -BaselineId $selectedBaseline -BaselinesPath $tenantConfig.BaselinesPath -Force:$ReloadBaselines.IsPresent
         }
         else { 
-          $baseline = Get-BaselineTemplate -BaselineId $selectedBaseline 
+          $baseline = Get-BaselineTemplate -BaselineId $selectedBaseline -Force:$ReloadBaselines.IsPresent
         }
       
         Write-Log "-----------------------------------------"

--- a/src/utilities/M365AdminCenter.psm1
+++ b/src/utilities/M365AdminCenter.psm1
@@ -74,7 +74,7 @@ Function Get-M365TenantSettingsServices {
         "MSGraphDataConnect" { @{name = $_; path = "admin/api/settings/apps/o365dataplan"; attr = "ServiceEnabled" } }
         "MSLoop" { @{name = $_; path = "admin/api/settings/apps/looppolicy"; attr = "LoopPolicy" } }
         "MSPlanner" { @{name = $_; path = "admin/api/services/apps/planner"; attr = "isPlannerAllowed" } }
-        "MSSearchBing" { @{name = $_; path = "fd/bfb/api/v3/office/switch/feature"; attr = "BingDefault" } }
+        "MSSearchBing" { @{name = $_; path = "admin/api/searchadminapi/configurations"; attr = "ServiceEnabled" } }
         "MSTeams" { @{name = $_; path = "admin/api/users/teamssettingsinfo"; attr = "IsTeamsEnabled" } }
         "MSTeamsAllowGuestAccess" { @{name = $_; path = "fd/IC3Config/Skype.Policy/configurations/TeamsClientConfiguration"; attr = "0.AllowGuestUser" } }
         # "MSToDo" { @{name = $_; path = "n/a" } }

--- a/src/utilities/TemplateFunctions.psm1
+++ b/src/utilities/TemplateFunctions.psm1
@@ -48,7 +48,10 @@ function Get-BaselineTemplate {
       Mandatory = $true
     )][string]$BaselineId,
     [Parameter(
-    )][string]$BaselinesPath = 'baselines'
+    )][string]$BaselinesPath = 'baselines',
+    [Parameter(
+      HelpMessage = "Force reload of baselines (overwrites already loaded baselines in memory by reading from file system)"
+    )][Switch]$Force = $false
   )
  
   Begin {
@@ -60,7 +63,7 @@ function Get-BaselineTemplate {
       throw "Invalid Baselines Path: '$BaselinesPath', execution stopped.`nPlease make sure the 'BaselinesPath' attribute in your tenant configuration file is set up correctly."
     }
 
-    if ($null -eq $Script:baselines) {
+    if ($null -eq $Script:baselines -or $Force.IsPresent) {
       try {
         $BaselinesFiles = @( Get-ChildItem -Path $ConfigPath\*.yml -ErrorAction SilentlyContinue )
       }


### PR DESCRIPTION
This PR solves two things:

- a bug that was reported in #47 while retrieving the tenant configuration for Bing according to the baseline M365.TENANT.1-1.1
- an enhancement to force reload all referenced baselines in a tenant configuration file when running the validation multiple times

Closes #47.