### PR TITLE
Add export options for reports in CSV and JSON formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,16 @@ New-Report -ValidationResults $result #-AsHTML
 > Optionally, you can also generate a HTML report in addition to the report in Markdown.
 > This offers a well-designed option which is suitable to put the validation results into a presentation or to share with management.
 
+In addition to the standard Markdown and HTML reports, the validation results can also be exported to a CSV or JSON file:
+
+```powershell
+# Generate a report in directory ./output, either as .csv or .json file
+New-Report -ValidationResults $result -AsCSV -AsJSON
+```
+
+> [!NOTE]
+> Due to the CSV data structure, the CSV report only contains a reduced set of validation results (hints and statistics are missing).
+
 ### Configuration baselines
 
 Every configuration baseline is a YAML file that contains an initial setup of configuration parameters for a specific service or a tenant. For example, here is the SharePoint Online baseline (as of 1 April 2024):

--- a/src/Public/Validation/New-Report.ps1
+++ b/src/Public/Validation/New-Report.ps1
@@ -44,7 +44,7 @@ Function New-Report {
 
       Function Add-MainContent([PSCustomObject]$resultSet, [PSCustomObject]$baseline) {
          $content = @()
-         $content += "`n## ► $($baseline.Topic) [Baseline ``$($resultSet.Baseline)``, Version $($resultSet.Version)]"
+         $content += "`n## ▶︎ $($baseline.Topic) [Baseline ``$($resultSet.Baseline)``, Version $($resultSet.Version)]"
          $content += "### Report Validation statistics"
          $content += "![total](https://img.shields.io/badge/Checks%20total-$($resultSet.Statistics.stats.Total)-blue.svg?style=flat-square)"
          $content += "![passed](https://img.shields.io/badge/✔%20Checks%20passed-$($resultSet.Statistics.stats.Passed)-green.svg?style=flat-square)"

--- a/src/Public/Validation/New-Report.ps1
+++ b/src/Public/Validation/New-Report.ps1
@@ -113,12 +113,12 @@ Function New-Report {
       # save report as Markdown
       [System.IO.Directory]::CreateDirectory($reportPath) # ensure directory exists
       $reportFilePath = "$($reportPath)/$($ValidationResults.Tenant)-$($currentTimeStamp.toString("yyyyMMddHHmm")) report"
-      $reportTemplate > $reportFilePath
-      Write-Log -Level INFO -Message "Markdown report created: $($reportFilePath)"
+      $reportTemplate > "$reportFilePath.md"
+      Write-Log -Level INFO -Message "Markdown report created: $($reportFilePath).md"
       
       # convert reports
       if ($AsHTML.IsPresent ) {
-         $htmlOutput = Convert-MarkdownToHTML $reportFilePath -SiteDirectory "$reportFilePath.md"
+         $htmlOutput = Convert-MarkdownToHTML "$reportFilePath.md" -SiteDirectory $reportPath
          Copy-Item -Path (Join-Path $PSScriptRoot -ChildPath '../../../assets/Report-styles.css') -Destination "$reportPath/styles/md-styles.css"
          Write-Log -Level INFO -Message "HTML report created: $($htmlOutput)"
       }

--- a/src/Public/Validation/New-Report.ps1
+++ b/src/Public/Validation/New-Report.ps1
@@ -126,13 +126,14 @@ Function New-Report {
          Write-Log -Level INFO -Message "Creating CSV report"
          $reportResultsPlain.Data = $ValidationResults.Validation | ForEach-Object {
             $resultSet = $_
-            $data = $resultSet.Result |`
-               Select-Object *, @{ Name = 'Baseline'; Expression = { $resultSet.Baseline } }, @{ Name = 'Version'; Expression = { $resultSet.Version } }
+            $data = $resultSet.Result | Select-Object *, `
+            @{ Name = 'Baseline'; Expression = { $resultSet.Baseline } }, `
+            @{ Name = 'Version'; Expression = { $resultSet.Version } }
             return $data
          } 
       
          $fileOutputPath = "$($reportPath)/$($ValidationResults.Tenant)-$($currentTimeStamp.toString("yyyyMMddHHmm")) report.csv"
-         $reportResultsPlain.Data | Export-Csv -Path $fileOutputPath
+         $reportResultsPlain.Data | Export-Csv -Path $fileOutputPath -Encoding UTF8 -Delimiter ';'
          Write-Log -Level INFO -Message "CSV report created: $($fileOutputPath)"
       }
    }

--- a/src/Public/Validation/New-Report.ps1
+++ b/src/Public/Validation/New-Report.ps1
@@ -33,7 +33,7 @@ Function New-Report {
       }
 
       $reportStatistics = @{ Total = 0; Passed = 0; Failed = 0; Manual = 0 }
-      $reportResultsPlain = @{ Data = @(); Report = $reportAtts };
+      $reportResultsPlain = [ordered]@{ Report = $reportAtts; Results = @() };
 
       Function Set-ReportStatistics($resultSet) {
          $reportStatistics.Total = $reportStatistics.Total + $resultSet.Statistics.stats.Total
@@ -125,7 +125,7 @@ Function New-Report {
       
       if ($AsCSV.IsPresent) {
          Write-Log -Level INFO -Message "Creating CSV report"
-         $reportResultsPlain.Data = $ValidationResults.Validation | ForEach-Object {
+         $reportResultsPlain.Results = $ValidationResults.Validation | ForEach-Object {
             $resultSet = $_
             $data = $resultSet.Result | Select-Object *, `
             @{ Name = 'Baseline'; Expression = { $resultSet.Baseline } }, `
@@ -134,13 +134,13 @@ Function New-Report {
          } 
       
          $fileOutputPath = "$reportFilePath.csv"
-         $reportResultsPlain.Data | Export-Csv -Path $fileOutputPath -Encoding UTF8 -Delimiter ';'
+         $reportResultsPlain.Results | Export-Csv -Path $fileOutputPath -Encoding UTF8 -Delimiter ';'
          Write-Log -Level INFO -Message "CSV report created: $($fileOutputPath)"
       }
 
       if ($AsJSON.IsPresent) {
          Write-Log -Level INFO -Message "Creating JSON report"
-         $reportResultsPlain.Data = $ValidationResults.Validation | ForEach-Object {
+         $reportResultsPlain.Results = $ValidationResults.Validation | ForEach-Object {
             return [ordered]@{
                Baseline   = $_.Baseline
                Version    = $_.Version
@@ -150,7 +150,7 @@ Function New-Report {
          } 
       
          $fileOutputPath = "$reportFilePath.json"
-         $reportResultsPlain.Data | ConvertTo-Json -Depth 10 | Out-File -FilePath $fileOutputPath
+         $reportResultsPlain | ConvertTo-Json -Depth 10 | Out-File -FilePath $fileOutputPath
          Write-Log -Level INFO -Message "JSON report created: $($fileOutputPath)"
       }
    }


### PR DESCRIPTION
Introduce functionality to export validation reports as CSV and JSON files, enhancing reporting capabilities. Update documentation to reflect these new options and address filename issues related to HTML output generation. 

Closes #18.