### PR TITLE
53 change check for required module dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get install xdg-utils -y
 # Install Powershell Moduels to Support Installation
 RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name powershell-yaml"
 RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name PnP.Powershell -RequiredVersion 2.12.0"
-RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name Microsoft.Graph -RequiredVersion 2.15.0"
-RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name Az.Accounts -RequiredVersion 2.19.0"
+RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name Microsoft.Graph -RequiredVersion 2.26.1"
+RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name Az.Accounts -RequiredVersion 4.0.2"
 RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name Az.Resources -RequiredVersion 6.4.0"
 RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name PSLogs -RequiredVersion 5.2.1"
 RUN pwsh -c "Install-Module -Force -Scope CurrentUser -Verbose -Name MarkdownPS -RequiredVersion 1.9"

--- a/src/utilities/CommonFunctions.psm1
+++ b/src/utilities/CommonFunctions.psm1
@@ -69,12 +69,12 @@ Function Test-RequiredModules {
       $currentVersion = [version]$m.Version
       if ($null -eq $m ) { 
         if ($null -eq $requiredVersion -or "" -eq $requiredVersion) {
-          throw "Test-RequiredModules Module '$($module.name)' is not installed: Install-Module $($module.name) -Scope CurrentUser" 
+          throw "[Test-RequiredModules] Module '$($module.name)' is not installed: Install-Module $($module.name) -Scope CurrentUser" 
         }
-        throw "Test-RequiredModules Module '$($module.name)' is not installed: Install-Module $($module.name) -RequiredVersion $($requiredVersion) -Scope CurrentUser" 
+        throw "[Test-RequiredModules] Module '$($module.name)' is not installed: Install-Module $($module.name) -RequiredVersion $($requiredVersion) -Scope CurrentUser" 
       }
       elseif ($null -ne $requiredVersion -and $currentVersion -lt $requiredVersion) { 
-        throw "Test-RequiredModules Module '$($module.name)' must refer at least to version $($requiredVersion): Install-Module $($module.name) -RequiredVersion $($module.version) -Scope CurrentUser" 
+        throw "[Test-RequiredModules] Module '$($module.name)' is version $($currentVersion) but must be at least version $($requiredVersion): Install-Module $($module.name) -RequiredVersion $($module.version) -Scope CurrentUser" 
       }
     }
     catch {

--- a/src/utilities/CommonFunctions.psm1
+++ b/src/utilities/CommonFunctions.psm1
@@ -39,7 +39,7 @@ Function Test-RequiredModules {
   $requiredModules = @(
     @{name = "powershell-yaml" }
     @{name = "PnP.PowerShell"; version = "2.12.0" }
-    @{name = "Microsoft.Graph"; version = "2.26.1" }
+    @{name = "Microsoft.Graph"; version = "2.25.1" }
     @{name = "Az.Accounts"; version = "4.0.2" }
     @{name = "Az.Resources"; version = "6.4.0" }
     @{name = "PSLogs"; version = "5.2.1" }
@@ -64,14 +64,17 @@ Function Test-RequiredModules {
   foreach ($module in $requiredModules) {
     try {
       $m = Get-Module -ListAvailable -Name $module.name | Sort-Object Version -Descending | Select-Object -First 1
+      
+      $requiredVersion = [version]$module.version
+      $currentVersion = [version]$m.Version
       if ($null -eq $m ) { 
-        if ($null -eq $module.version -or "" -eq $module.version) {
+        if ($null -eq $requiredVersion -or "" -eq $requiredVersion) {
           throw "Test-RequiredModules Module '$($module.name)' is not installed: Install-Module $($module.name) -Scope CurrentUser" 
         }
-        throw "Test-RequiredModules Module '$($module.name)' is not installed: Install-Module $($module.name) -RequiredVersion $($module.version) -Scope CurrentUser" 
+        throw "Test-RequiredModules Module '$($module.name)' is not installed: Install-Module $($module.name) -RequiredVersion $($requiredVersion) -Scope CurrentUser" 
       }
-      elseif ($null -ne $module.version -and $module.version -notin @($m.Version.ToString(), "")) { 
-        throw "Test-RequiredModules Module '$($module.name)' must refer to version $($module.version): Install-Module $($module.name) -RequiredVersion $($module.version) -Scope CurrentUser" 
+      elseif ($null -ne $requiredVersion -and $currentVersion -lt $requiredVersion) { 
+        throw "Test-RequiredModules Module '$($module.name)' must refer at least to version $($requiredVersion): Install-Module $($module.name) -RequiredVersion $($module.version) -Scope CurrentUser" 
       }
     }
     catch {

--- a/src/utilities/CommonFunctions.psm1
+++ b/src/utilities/CommonFunctions.psm1
@@ -39,7 +39,7 @@ Function Test-RequiredModules {
   $requiredModules = @(
     @{name = "powershell-yaml" }
     @{name = "PnP.PowerShell"; version = "2.12.0" }
-    @{name = "Microsoft.Graph"; version = "2.25.1" }
+    @{name = "Microsoft.Graph"; version = "2.26.1" }
     @{name = "Az.Accounts"; version = "4.0.2" }
     @{name = "Az.Resources"; version = "6.4.0" }
     @{name = "PSLogs"; version = "5.2.1" }


### PR DESCRIPTION
This pull request includes updates to PowerShell module versions and improvements to the `Test-RequiredModules` function to enhance version checking and error messages.

Closes #53.

### PowerShell Module Updates:
* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L12-R13): Updated `Microsoft.Graph` to version `2.26.1` and `Az.Accounts` to version `4.0.2` to ensure compatibility with the latest features and security patches.

### Improvements to Module Version Checking:
* [`src/utilities/CommonFunctions.psm1`](diffhunk://#diff-bc1b603f6cd1f31f04369e5dd7fe75ec9ee009e01941a32980e1fda580843630R67-R77): Enhanced the `Test-RequiredModules` function by changing version comparison logic for installed versions to match _at least_ the required version (instead of matching _exact_) and improving error messages for better clarity and debugging.